### PR TITLE
chore: Standardize CI workflow PR titles and bodies

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -96,9 +96,25 @@ jobs:
 
           # Create PR using GitHub CLI
           echo "${{ secrets.GITOPS_PAT }}" | gh auth login --with-token
+          PR_BODY="Automated GitOps Update
+
+          - **Service**: ChatbotService
+          - **Environment**: Development
+          - **Image Tag**: ${{ github.sha }}
+          - **Source Branch**: ${{ github.ref_name }}
+          - **Commit**: ${{ github.sha }}
+
+          Updates maliev-chatbot-service image in development overlay.
+          This PR was automatically created by GitHub Actions.
+          Once merged, ArgoCD will automatically sync the changes to the maliev-dev namespace.
+
+          Triggered by: ${{ github.actor }}
+          Workflow: ${{ github.workflow }}
+          Run: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
           gh pr create \
             --repo MALIEV-Co-Ltd/maliev-gitops \
             --base main \
             --head "$BRANCH_NAME" \
-            --title "chore(dev): Update ChatbotService to ${{ github.sha }}" \
-            --body "Automated GitOps Update - Service: ChatbotService, Environment: Development, Image Tag: ${{ github.sha }}, Source Branch: develop, Commit: ${{ github.sha }}. Updates maliev-chatbot-service image in development overlay. This PR was automatically created by GitHub Actions. Once merged, ArgoCD will automatically sync the changes to the maliev-dev namespace. Triggered by: ${{ github.actor }}, Workflow: ${{ github.workflow }}, Run: ${{ github.run_id }}"
+            --title "chore(dev): Update chatbot-service" \
+            --body "$PR_BODY"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -96,9 +96,26 @@ jobs:
 
           # Create PR using GitHub CLI
           echo "${{ secrets.GITOPS_PAT }}" | gh auth login --with-token
+          PR_BODY="Automated GitOps Update - **PRODUCTION**
+
+          - **Service**: ChatbotService
+          - **Environment**: Production
+          - **Image Tag**: ${{ github.sha }}
+          - **Source Branch**: ${{ github.ref_name }}
+          - **Commit**: ${{ github.sha }}
+
+          Updates maliev-chatbot-service image in production overlay.
+          **WARNING**: This is a production deployment and should be reviewed before merging.
+          This PR was automatically created by GitHub Actions.
+          Once merged, ArgoCD will automatically sync the changes to the maliev-prod namespace.
+
+          Triggered by: ${{ github.actor }}
+          Workflow: ${{ github.workflow }}
+          Run: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
           gh pr create \
             --repo MALIEV-Co-Ltd/maliev-gitops \
             --base main \
             --head "$BRANCH_NAME" \
-            --title "chore(prod): Update ChatbotService to ${{ github.sha }}" \
-            --body "Automated GitOps Update - PRODUCTION - Service: ChatbotService, Environment: Production, Image Tag: ${{ github.sha }}, Source Branch: main, Commit: ${{ github.sha }}. Updates maliev-chatbot-service image in production overlay. WARNING: PRODUCTION DEPLOYMENT - This PR was automatically created by GitHub Actions. Once merged, ArgoCD will automatically sync the changes to the maliev-prod namespace. Triggered by: ${{ github.actor }}, Workflow: ${{ github.workflow }}, Run: ${{ github.run_id }}. APPROVAL REQUIRED: This is a production deployment and should be reviewed before merging."
+            --title "chore(prod): Update chatbot-service" \
+            --body "$PR_BODY"

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -96,9 +96,25 @@ jobs:
 
           # Create PR using GitHub CLI
           echo "${{ secrets.GITOPS_PAT }}" | gh auth login --with-token
+          PR_BODY="Automated GitOps Update
+
+          - **Service**: ChatbotService
+          - **Environment**: Staging
+          - **Image Tag**: ${{ github.sha }}
+          - **Source Branch**: ${{ github.ref_name }}
+          - **Commit**: ${{ github.sha }}
+
+          Updates maliev-chatbot-service image in staging overlay.
+          This PR was automatically created by GitHub Actions.
+          Once merged, ArgoCD will automatically sync the changes to the maliev-staging namespace.
+
+          Triggered by: ${{ github.actor }}
+          Workflow: ${{ github.workflow }}
+          Run: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
           gh pr create \
             --repo MALIEV-Co-Ltd/maliev-gitops \
             --base main \
             --head "$BRANCH_NAME" \
-            --title "chore(staging): Update ChatbotService to ${{ github.sha }}" \
-            --body "Automated GitOps Update - Service: ChatbotService, Environment: Staging, Image Tag: ${{ github.sha }}, Source Branch: ${{ github.ref }}, Commit: ${{ github.sha }}. Updates maliev-chatbot-service image in staging overlay. This PR was automatically created by GitHub Actions. Once merged, ArgoCD will automatically sync the changes to the maliev-staging namespace. Triggered by: ${{ github.actor }}, Workflow: ${{ github.workflow }}, Run: ${{ github.run_id }}"
+            --title "chore(staging): Update chatbot-service" \
+            --body "$PR_BODY"


### PR DESCRIPTION
This PR standardizes the CI workflows across the service to use consistent branch-aware PR titles and detailed, multiline PR bodies for better readability and traceability in GitOps updates.

Changes:
- Standardized PR titles to \chore(<env>): Update <service-name>\
- Implemented multiline PR bodies with service, environment, image tag, and workflow details.
- Added production warning for main branch deployments.